### PR TITLE
Get tests passing for Django 2

### DIFF
--- a/pinax/invitations/migrations/0001_initial.py
+++ b/pinax/invitations/migrations/0001_initial.py
@@ -43,4 +43,3 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
     ]
-on_delete will be a required arg for ForeignKey/OneToOneField in Django 2.0

--- a/pinax/invitations/migrations/0001_initial.py
+++ b/pinax/invitations/migrations/0001_initial.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('invites_sent', models.IntegerField(default=0)),
                 ('invites_allocated', models.IntegerField(default=0)),
                 ('invites_accepted', models.IntegerField(default=0)),
-                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -34,12 +34,13 @@ class Migration(migrations.Migration):
                 ('message', models.TextField(null=True)),
                 ('sent', models.DateTimeField(default=django.utils.timezone.now)),
                 ('status', models.IntegerField(choices=[(1, b'Sent'), (2, b'Accepted'), (3, b'Joined Independently')])),
-                ('from_user', models.ForeignKey(related_name='invites_sent', to=settings.AUTH_USER_MODEL)),
-                ('signup_code', models.OneToOneField(to='account.SignupCode')),
-                ('to_user', models.ForeignKey(related_name='invites_received', to=settings.AUTH_USER_MODEL, null=True)),
+                ('from_user', models.ForeignKey(related_name='invites_sent', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
+                ('signup_code', models.OneToOneField(to='account.SignupCode', on_delete=models.CASCADE)),
+                ('to_user', models.ForeignKey(related_name='invites_received', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True)),
             ],
             options={
             },
             bases=(models.Model,),
         ),
     ]
+on_delete will be a required arg for ForeignKey/OneToOneField in Django 2.0

--- a/pinax/invitations/models.py
+++ b/pinax/invitations/models.py
@@ -39,7 +39,7 @@ class JoinInvitation(models.Model):
     message = models.TextField(null=True)
     sent = models.DateTimeField(default=timezone.now)
     status = models.IntegerField(choices=INVITE_STATUS_CHOICES)
-    signup_code = models.OneToOneField(SignupCode)
+    signup_code = models.OneToOneField(SignupCode, on_delete=models.CASCADE)
 
     def to_user_email(self):
         return self.signup_code.email

--- a/pinax/invitations/models.py
+++ b/pinax/invitations/models.py
@@ -25,9 +25,14 @@ class JoinInvitation(models.Model):
         (STATUS_JOINED_INDEPENDENTLY, "Joined Independently")
     ]
 
-    from_user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="invites_sent")
+    from_user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="invites_sent",
+    )
     to_user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
+        on_delete = models.CASCADE,
         null=True,
         related_name="invites_received"
     )
@@ -92,7 +97,7 @@ class JoinInvitation(models.Model):
 
 class InvitationStat(models.Model):
 
-    user = models.OneToOneField(settings.AUTH_USER_MODEL)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     invites_sent = models.IntegerField(default=0)
     invites_allocated = models.IntegerField(
         default=settings.PINAX_INVITATIONS_DEFAULT_INVITE_ALLOCATION

--- a/pinax/invitations/models.py
+++ b/pinax/invitations/models.py
@@ -32,7 +32,7 @@ class JoinInvitation(models.Model):
     )
     to_user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
-        on_delete = models.CASCADE,
+        on_delete=models.CASCADE,
         null=True,
         related_name="invites_received"
     )

--- a/pinax/invitations/urls.py
+++ b/pinax/invitations/urls.py
@@ -9,6 +9,7 @@ from .views import (
     TopOffUserView
 )
 
+app_name = "pinax_invitations"
 
 urlpatterns = [
     url(r"^invite/$", InviteView.as_view(), name="invite"),


### PR DESCRIPTION
Mainly required adding `on_delete` to model FK and OneToOne fields, and adding `app_name` to urls.py for Django v2 explicit namespacing.

All tests should now pass in all desired Django/Python configurations.