### PR TITLE
Fix `render_to_string()` kwarg

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Django \ Python | 2.7 | 3.4 | 3.5 | 3.6
 
 ## Documentation
 
-The `pinax-invitations` documentation is currently under construction. If you would like to help us write documentation, please join our Slack team and let us know! 
-
 ### Installation
 
 To install pinax-invitations:

--- a/README.md
+++ b/README.md
@@ -324,6 +324,11 @@ Fragment displays how many invites a particular user has.
 
 ## Change Log
 
+### 6.1.2
+
+* Replace deprecated `context_instance=RequestContext(r)` kwarg with `request=r`
+* Add InviteView smoke tests
+
 ### 6.1.1
 
 * Add django>=1.11 to requirements

--- a/pinax/invitations/tests/tests.py
+++ b/pinax/invitations/tests/tests.py
@@ -1,10 +1,10 @@
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.test import TestCase
 
 from account.models import SignupCode
 from pinax.invitations.forms import InviteForm
 from pinax.invitations.models import InvitationStat, JoinInvitation
+from test_plus.test import TestCase
 
 
 class TestsJoinInvitation(TestCase):
@@ -73,3 +73,26 @@ class FormTests(TestCase):
         }
         form = InviteForm(user=from_user, data=form_data)
         self.assertFalse(form.is_valid())
+
+
+class ViewTests(TestCase):
+
+    def test_invite_view(self):
+        """verify no errors when posting good form data"""
+        user = self.make_user("amy")
+        InvitationStat.add_invites(2)
+        post_data = {
+            "email_address": "amy@example.com"
+        }
+        with self.login(user):
+            self.post("pinax_invitations:invite", data=post_data)
+            self.response_200()
+
+    def test_invite_view_bad_data(self):
+        """verify no errors when posting bad data"""
+        user = self.make_user("sandee")
+        post_data = {
+        }
+        with self.login(user):
+            self.post("pinax_invitations:invite", data=post_data)
+            self.response_200()

--- a/pinax/invitations/tests/urls.py
+++ b/pinax/invitations/tests/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 
 urlpatterns = [
+    url(r"^account", include("account.urls")),
     url(r"^", include("pinax.invitations.urls", namespace="pinax_invitations")),
 ]

--- a/pinax/invitations/views.py
+++ b/pinax/invitations/views.py
@@ -29,18 +29,18 @@ class InviteView(LoginRequiredMixin, FormMixin, View):
                 self.invite_form_fragment, {
                     "form": form,
                     "user": self.request.user
-                }, context_instance=RequestContext(self.request)
+                }, request=self.request
             ),
             "fragments": {
                 self.invites_remaining_fragment_selector: render_to_string(
                     self.invites_remaining_fragment, {
                         "invites_remaining": self.request.user.invitationstat.invites_remaining()
-                    }, context_instance=RequestContext(self.request)
+                    }, request=self.request
                 ),
                 self.invited_fragment_selector: render_to_string(
                     self.invited_fragment, {
                         "invited_list": self.request.user.invites_sent.all()
-                    }, context_instance=RequestContext(self.request)
+                    }, request=self.request
                 )
             }
         }

--- a/runtests.py
+++ b/runtests.py
@@ -6,15 +6,21 @@ import django
 
 from django.conf import settings
 
-
 DEFAULT_SETTINGS = dict(
     INSTALLED_APPS=[
         "django.contrib.auth",
         "django.contrib.contenttypes",
+        "django.contrib.sessions",
         "django.contrib.sites",
         "account",
+        "bootstrapform",
         "pinax.invitations",
-        "pinax.invitations.tests"
+        "pinax.invitations.tests",
+        "pinax.templates",
+    ],
+    MIDDLEWARE=[
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
     ],
     DATABASES={
         "default": {
@@ -25,6 +31,18 @@ DEFAULT_SETTINGS = dict(
     SITE_ID=1,
     ROOT_URLCONF="pinax.invitations.tests.urls",
     SECRET_KEY="notasecret",
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "debug": True,
+                "context_processors": [
+                    "django.contrib.auth.context_processors.auth",
+                ]
+            }
+        },
+    ],
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "6.1.1"
+VERSION = "6.1.2"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-invitations.svg
     :target: https://pypi.python.org/pypi/pinax-invitations/
@@ -61,14 +61,6 @@ setup(
     package_data={
         "invitations": []
     },
-    install_requires=[
-        "django>=1.11",
-        "django-appconf>=1.0.1",
-        "django-user-accounts>=2.0.3",
-    ],
-    test_suite="runtests.runtests",
-    tests_require=[
-    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -86,6 +78,16 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    install_requires=[
+        "django>=1.11",
+        "django-appconf>=1.0.1",
+        "django-user-accounts>=2.0.3",
+    ],
+    test_suite="runtests.runtests",
+    tests_require=[
+        "django-test-plus",
+        "pinax-templates>=1.0.2",
     ],
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ inline-quotes = double
 [isort]
 multi_line_output=3
 known_django=django
-known_third_party=account,appconf,pinax
+known_third_party=account,appconf,pinax,test_plus
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 include_trailing_comma=True
 skip_glob=**/*/migrations/*


### PR DESCRIPTION
* Replace deprecated `context_instance=RequestContext(r)` kwarg with `request=r` in `render_to_string()` kwargs.
* Add InviteView smoke tests.
* Add form test.
* Incorporate django-test-plus dependency for testing

